### PR TITLE
Fix parsing locale from context

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -4,6 +4,21 @@ const chalk = require('chalk');
 const get = require('lodash.get');
 const templite = require('templite');
 
+// should match "/en/", "/en-US/", "/en_US/"
+const contextLocaleRegex = /^\/([a-z]{2,}(?:[_-][a-z]{2,})?)\//i;
+
+/**
+ * Parses string looking like a lang code from the beginning of the url or filePathStem
+ *
+ * @param {string} path
+ * @return {string|null}
+ * @private
+ */
+function getContextLocale(path) {
+  const match = contextLocaleRegex.exec(path || '');
+  return match && match[1];
+}
+
 module.exports = function (
   key,
   data = {},
@@ -17,12 +32,13 @@ module.exports = function (
   } = pluginOptions;
 
   // Use explicit `locale` argument if passed in, otherwise infer it from URL prefix segment
-  const url = get(page, 'url', '');
-  const contextLocale = url.split('/')[1];
+  const url = get(page, 'filePathStem') || '';
+  const contextLocale = typeof url === 'string' ? getContextLocale(url) : '';
+
   const locale = localeOverride || contextLocale;
 
   // Preferred translation
-  const translation = get(translations, `[${key}][${locale}]`);
+  const translation = locale == null ? undefined : get(translations, `[${key}][${locale}]`);
 
   if (translation !== undefined) {
     return templite(translation, data);


### PR DESCRIPTION
Fixes #4 by parsing context locale from `page.filePathStem` instead of `page.url`. 

This should be considered a breaking change, especially because of regexp