### PR TITLE
Add the ability to customize the context locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ fallbackLocales: {
 
 👀 `eleventy-plugin-i18n` will warn you in the Node console when the intended translation or fallback values can't be found for a given language based on your `translations` data.
 
+#### `contextLocale`
+
+Type: `function` | Default: ‌`(page, config) => get(page, 'url', '').split('/')[1]`
+
+You might provide a function in order to compute the context locale (that is, the locale applied to the `i18n` filter when no arguments are provided). By default, this would be the first segment of the URL (`/en/`, `/it/` and so on). If you use a custom directory strategy, like not prefixing the current locale, this option comes to help. The first argument of the function is the `page` object (could be `undefined`), the second is the plugin `config` object.
+
 ## Usage
 
 Once configured, the `i18n` [Universal filter](https://www.11ty.dev/docs/filters/#universal-filters) is available throughout Nunjucks, Handlebars, Liquid, and JavaScript templates and includes. E.g. To return the translation for our `hello` key in Nunjucks or Liquid syntax:

--- a/i18n.js
+++ b/i18n.js
@@ -13,13 +13,13 @@ module.exports = function (
 ) {
   const {
     translations = {},
-    fallbackLocales: fallbackLocales = {}
+    fallbackLocales: fallbackLocales = {},
+    contextLocale: contextLocale = page => get(page, 'url', '').split('/')[1]
   } = pluginOptions;
 
   // Use explicit `locale` argument if passed in, otherwise infer it from URL prefix segment
-  const url = get(page, 'url', '');
-  const contextLocale = url.split('/')[1];
-  const locale = localeOverride || contextLocale;
+  // (or use the provided function to compute it)
+  const locale = localeOverride || contextLocale(page, pluginOptions);
 
   // Preferred translation
   const translation = get(translations, `[${key}][${locale}]`);


### PR DESCRIPTION
Related to issue #8.

Quick overview (taken from the updated README):

#### `contextLocale`

Type: `function` | Default: ‌`(page, config) => get(page, 'url', '').split('/')[1]`

You might provide a function in order to compute the context locale (that is, the locale applied to the `i18n` filter when no arguments are provided). By default, this would be the first segment of the URL (`/en/`, `/it/` and so on). If you use a custom directory strategy, like not prefixing the current locale, this option comes to help. The first argument of the function is the `page` object (could be `undefined`), the second is the plugin `config` object.