### PR TITLE
Workaround for permalink: false bug

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -16,8 +16,8 @@ module.exports = function (
     fallbackLocales: fallbackLocales = {}
   } = pluginOptions;
 
-  // Use explicit `locale` argument if passed in, otherwise infer it from URL prefix segment
-  const url = get(page, 'url', '');
+  // Use explicit `locale` argument if passed in, otherwise infer it from directory prefix segment
+  const url = get(page, 'filePathStem', '');
   const contextLocale = url.split('/')[1];
   const locale = localeOverride || contextLocale;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-i18n",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-i18n",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Eleventy plugin to assist with dictionary translations",
   "main": ".eleventy.js",
   "scripts": {


### PR DESCRIPTION
Flagged by @unconfident in #4.

Existing implementation makes use of `page.url` to deduce locale. It was already a bit of a flimsy premise, but will throw an error if authors decide to `permalink: false` any pages (which is totally [fair game](https://www.11ty.dev/docs/permalinks/#permalink-false) in 11ty).

This doesn't solve #4 entirely, but will prevent the error in the meantime.