### PR TITLE
Simplest quite mode implementation for plugin

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,7 +2,8 @@ const i18n = require('./i18n.js');
 
 const defaultOptions = {
   translations: {},
-  fallbackLocales: {}
+  fallbackLocales: {},
+  quiteMode: false
 };
 
 module.exports = function (eleventyConfig, configGlobalOptions = {}) {

--- a/i18n.js
+++ b/i18n.js
@@ -13,7 +13,8 @@ module.exports = function (
 ) {
   const {
     translations = {},
-    fallbackLocales: fallbackLocales = {}
+    fallbackLocales: fallbackLocales = {},
+    quiteMode = false
   } = pluginOptions;
 
   // Use explicit `locale` argument if passed in, otherwise infer it from URL prefix segment
@@ -34,19 +35,24 @@ module.exports = function (
   const fallbackTranslation = get(translations, `[${key}][${fallbackLocale}]`);
 
   if (fallbackTranslation !== undefined) {
-    console.warn(
-      chalk.yellow(
-        `[i18n] Could not find '${key}' in '${locale}'. Using '${fallbackLocale}' fallback.`
-      )
-    );
+    if (!quiteMode) {
+      console.warn(
+        chalk.yellow(
+          `[i18n] Could not find '${key}' in '${locale}'. Using '${fallbackLocale}' fallback.`
+        )
+      );
+    }
     return templite(fallbackTranslation, data);
   }
 
+  
   // Not found
-  console.warn(
-    chalk.red(
-      `[i18n] Translation for '${key}' in '${locale}' not found. No fallback locale specified.`
-    )
-  );
+  if (!quiteMode) {
+    console.warn(
+      chalk.red(
+        `[i18n] Translation for '${key}' in '${locale}' not found. No fallback locale specified.`
+      )
+    );
+  }
   return key;
 };


### PR DESCRIPTION
Hi @adamduncan! 
First of all, thank you for your plugin! Works great :)
Quiet mode is a need for me, so I'm proposing simplest flag to have an ability to suppress warnings / errors in console.
I know it can be improved as option to choose between `warnings`  and  `errors`  or even  `all` output, so please let me know what is your vision regarding this option.