### PR TITLE
Extend dictionaries on a per-page basis

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -19,6 +19,9 @@ module.exports = function (eleventyConfig, configGlobalOptions = {}) {
   eleventyConfig.addFilter('i18n', function (key, data, localeOverride) {
     // TBC Here we need to determine if filter is being used on page or in include, respectively
     const page = this.page || this.ctx.page;
-    return i18n(key, data, localeOverride, pluginOptions, page);
+    const pageContext = this?.ctx || this.context?.environments;
+    const pageDictionary = pageContext?.i18n || {};
+
+    return i18n(key, data, localeOverride, pluginOptions, page, pageDictionary);
   });
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.1",
+    "deepmerge": "^4.2.2",
     "lodash.get": "^4.4.2",
     "templite": "^1.1.0"
   },


### PR DESCRIPTION
As proposed in #23 I extended this plugin instead of providing a custom implementation: easier to see what's going on!

This adds the ability to extend the dictionary on a per-page basis by reading the available data in the context (e.g. data added in the frontmatter) and pulling it in under the `i18n` key.

This lets you add translations in the frontmatter for a specific page that might use a layout shared across languages, enabling you to add one-off translations that won't clutter up your base dictionaries.

**Example**

📄 src/en/about.njk
```
---
title: About
layout: layouts/about.njk
i18n:
  favouriteFood: Lasagna
---

Hi, I am an example.
```

📄 src/fr/about.njk
```
---
title: À Propos
layout: layouts/about.njk
i18n:
  favouriteFood: Lasagnes
---

Bonjour, je suis un exemple.
```

📄 src/_includes/layouts/about.njk
```
<aside>😋 = {{ 'favouriteFood' | i18n }}</aside>
```

The `favouriteFood` key does not exist in `en.json` or `fr.json` but can be accessed by adding it to each localised content file.