### PR TITLE
Use the `lang` `page` variable attribute

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -14,10 +14,8 @@ module.exports = function (
   const { translations = {}, fallbackLocales: fallbackLocales = {} } =
     pluginOptions;
 
-  // Use explicit `locale` argument if passed in, otherwise infer it from URL prefix segment
-  const url = get(page, 'url', '');
-  const contextLocale = url.split('/')[1];
-  const locale = localeOverride || contextLocale;
+  // Use explicit `locale` argument if passed in, otherwise use the `lang` `page` variable attribute available in 2.0
+  const locale = localeOverride || get(page, 'lang', '');
 
   // Preferred translation
   const translation = get(translations, `[${key}][${locale}]`);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eleventy-plugin-i18n",
+  "name": "@codegouvfr/eleventy-plugin-i18n",
   "version": "0.1.3",
   "description": "Eleventy plugin to assist with dictionary translations",
   "main": ".eleventy.js",


### PR DESCRIPTION
Hi!

Since the version 2.0 of 11ty, a `lang` attribute has been available in the `page` variable.

I am suggesting this PR to reflect this addition and use this handy attribute directly rather than inferring the lang from the URL.

Thanks in advance!